### PR TITLE
Perform previous search when search term is empty

### DIFF
--- a/plugin/eregex.vim
+++ b/plugin/eregex.vim
@@ -712,10 +712,13 @@ endfunction
 "end E2v()
 "-----------------------------------------------------------------------------
 function! s:Ematch(...)
-    if strlen(a:2) <= 1 | return | endif
-
     let ccount = a:1
-    let string = a:2
+    if strlen(a:2) <= 1
+        let string = a:2 . @/
+    else
+        let string = a:2
+    endif
+
     let delim=string[0]
 
     if delim !=# '/' && delim !=# '?' 
@@ -766,7 +769,7 @@ function! s:Ematch(...)
     if v:errmsg ==# ''
         redraw!
     else
-        echo 'M' . a:2
+        echo 'M' . string
         echo v:errmsg
     endif
 


### PR DESCRIPTION
By default, the "/" and "?" commands in vim will search for the previous search term if no search is supplied.
