### PR TITLE
correctly handle &ignorecase and &smartcase (re-fixes #4 and #7)

### DIFF
--- a/plugin/eregex.vim
+++ b/plugin/eregex.vim
@@ -742,10 +742,6 @@ function! s:Ematch(...)
         let offset = substitute(offset, '\C[' . s:str_modifiers . ']\+', "", "g")
     endif
 
-    if &ignorecase && match(modifiers, 'I') == -1
-      let modifiers .= 'i'
-    endif
-
     let regex = s:ExtendedRegex2VimRegex(regex, modifiers)
     "v130
     "set s:bakregex
@@ -805,9 +801,6 @@ function! s:Esubstitute(...) range
     if options =~# '[' . s:str_modifiers . ']'
         let modifiers = substitute(options, '\C[^' . s:str_modifiers . ']\+', "", "g")
         let options = substitute(options, '\C[SCDmM]', "", "g")
-    endif
-    if &ignorecase && match(modifiers, 'I') == -1
-      let modifiers .= 'i'
     endif
 
     let regex = s:ExtendedRegex2VimRegex(regex, modifiers)


### PR DESCRIPTION
before (breaks `&smartcase`):

* default modifier to `/i` if `&ignorecase` and not `/I`

after (honours `&ignorecase` and `&smartcase`):

* no default modifier i.e. vim default
* override defaults with `(?i)`, `(?I)`, `\c`, `\C`, `/i` and `/I`