### PR TITLE
Add multibyte chars at 1st line of ja help document

### DIFF
--- a/doc/eregex.jax
+++ b/doc/eregex.jax
@@ -1,4 +1,4 @@
-*eregex.jax*
+*eregex.jax* 日本語ドキュメント
 
     ファイル:       eregex.vim, eregex_e.vim
     作者:           AKUTSU toshiyuki <locrian@mbd.ocn.ne.jp>


### PR DESCRIPTION
 - Vim checks firstline of help file whether it contains multibyte character or not for detecting help file's encoding.

- Currently ja help doc makes following errors:

```
Vim(helptags):E670: Mix of help file encodings within a language: /Users/takanabe/.vim/bundle/.neobundle/doc/eregex.jax
````