### PR TITLE
support incsearch

### DIFF
--- a/plugin/incsearch.vim
+++ b/plugin/incsearch.vim
@@ -13,11 +13,13 @@ augroup eregex_incsearch_augroup
 augroup END
 
 if !has('nvim')
-    function! K_eregex_incsearch_abort_cr()
-        let s:eregex_incsearch_abort = 0
-        return "\<cr>"
-    endfunction
-    cnoremap <expr> <cr> K_eregex_incsearch_abort_cr()
+    if get(g:, 'eregex_incsearch_abort_fix', 1)
+        function! _eregex_incsearch_abort_cr()
+            let g:eregex_incsearch_abort = 0
+            return "\<cr>"
+        endfunction
+        cnoremap <expr> <cr> _eregex_incsearch_abort_cr()
+    endif
 endif
 
 " it's buggy if update immediately on #CmdlineChanged,
@@ -56,7 +58,7 @@ function! s:onUpdate()
     if !exists('s:patternSaved')
         let s:patternSaved = @/
         if !has('nvim')
-            let s:eregex_incsearch_abort = 1
+            let g:eregex_incsearch_abort = 1
         endif
     endif
     if !exists('s:stateSaved')
@@ -119,7 +121,7 @@ function! s:onLeave()
     if has('nvim')
         let abort = get(v:event, 'abort', 0)
     else
-        let abort = get(s:, 'eregex_incsearch_abort', 0)
+        let abort = get(g:, 'eregex_incsearch_abort', 0)
     endif
     if !abort
         return

--- a/plugin/incsearch.vim
+++ b/plugin/incsearch.vim
@@ -157,7 +157,7 @@ function! s:cmdParse(cmdline)
     let modes = get(b:, 'eregex_incsearch_modes', get(g:, 'eregex_incsearch_modes', 'MSGV'))
     " ^[0-9,\.\$%]*([MSGV])\/.*$
     let method = substitute(items[0], '^[0-9,\.\$%]*\([' . modes . ']\)\/.*$', '\1', '')
-    if empty(method)
+    if empty(method) || len(method) != 1
         return {}
     endif
     return {

--- a/plugin/incsearch.vim
+++ b/plugin/incsearch.vim
@@ -195,6 +195,15 @@ function! s:cmdParse(cmdline)
     let method = substitute(cmdline, '^[0-9,\.\$% \t]*\([' . modes . ']\)[ \t]*\([' . delims . ']\).*$', '\1', '')
     let delim  = substitute(cmdline, '^[0-9,\.\$% \t]*\([' . modes . ']\)[ \t]*\([' . delims . ']\).*$', '\2', '')
     if len(method) != 1 || len(delim) != 1
+        " {
+        "   'module_name' : function(cmdline),
+        " }
+        for Fn in values(get(g:, 'eregex_incsearch_custom_cmdparser', {}))
+            let ret = Fn(a:cmdline)
+            if !empty(ret)
+                return ret
+            endif
+        endfor
         return {}
     endif
 

--- a/plugin/incsearch.vim
+++ b/plugin/incsearch.vim
@@ -87,7 +87,11 @@ function! s:onUpdate()
     if !empty(pattern)
         let @/ = pattern
 
-        let pos = searchpos(pattern, backward ? 'bcnw' : 'cnwz')
+        try
+            silent! let pos = searchpos(pattern, backward ? 'bcnw' : 'cnwz')
+        catch
+            let pos = [0, 0]
+        endtry
         if pos[0] > 0 && pos[1] > 0
             " 'reverse' the cursor by one char so that the next `:M` action
             " would jump to the nearest position

--- a/plugin/incsearch.vim
+++ b/plugin/incsearch.vim
@@ -155,8 +155,8 @@ function! s:cmdParse(cmdline)
         return {}
     endif
     let modes = get(b:, 'eregex_incsearch_modes', get(g:, 'eregex_incsearch_modes', 'MSGV'))
-    " ^[0-9,\.\$%]*([MSGV])\/.*$
-    let method = substitute(items[0], '^[0-9,\.\$%]*\([' . modes . ']\)\/.*$', '\1', '')
+    " ^[0-9,\.\$% ]*([MSGV]) *$
+    let method = substitute(items[0], '^[0-9,\.\$% ]*\([' . modes . ']\) *$', '\1', '')
     if empty(method) || len(method) != 1
         return {}
     endif

--- a/plugin/incsearch.vim
+++ b/plugin/incsearch.vim
@@ -1,0 +1,166 @@
+
+if !get(g:, 'eregex_incsearch_enable', 1)
+            \ || !exists('##CmdlineChanged')
+            \ || !exists('##CmdlineLeave')
+            \ || !has('timers')
+    finish
+endif
+
+augroup eregex_incsearch_augroup
+    autocmd!
+    autocmd CmdlineChanged * call s:delayUpdate()
+    autocmd CmdlineLeave * call s:onLeave()
+augroup END
+
+if !has('nvim')
+    function! K_eregex_incsearch_abort_cr()
+        let s:eregex_incsearch_abort = 0
+        return "\<cr>"
+    endfunction
+    cnoremap <expr> <cr> K_eregex_incsearch_abort_cr()
+endif
+
+" it's buggy if update immediately on #CmdlineChanged,
+" especially for keymap such as
+"     nnoremap xxx :S/<c-r><c-w>
+function! s:delayUpdate()
+    if get(s:, 'delayUpdateId', -1) == -1
+        let s:delayUpdateId = timer_start(10, function('s:delayUpdateAction'))
+    endif
+endfunction
+function! s:delayUpdateCancel()
+    if get(s:, 'delayUpdateId', -1) != -1
+        call timer_stop(s:delayUpdateId)
+        let s:delayUpdateId = -1
+    endif
+endfunction
+function! s:delayUpdateAction(...)
+    let s:delayUpdateId = -1
+    call s:onUpdate()
+endfunction
+
+function! s:onUpdate()
+    if getcmdtype() != ':'
+                \ || !get(b:, 'eregex_incsearch', get(g:, 'eregex_incsearch', &incsearch))
+        return
+    endif
+    let cmd = s:cmdParse(getcmdline())
+    if empty(cmd)
+        return
+    endif
+    let pattern = E2v(cmd['pattern'])
+
+    if !exists('s:hlsearchSaved')
+        let s:hlsearchSaved = &hlsearch
+    endif
+    if !exists('s:patternSaved')
+        let s:patternSaved = @/
+        if !has('nvim')
+            let s:eregex_incsearch_abort = 1
+        endif
+    endif
+    if !exists('s:stateSaved')
+        let s:stateSaved = winsaveview()
+    endif
+
+    set nohlsearch
+
+    if !empty(pattern)
+        let @/ = pattern
+
+        let pos = searchpos(pattern, 'cnw')
+        if pos[0] > 0 && pos[1] > 0
+            if pos[1] > 1
+                let pos[1] -= 1
+            endif
+            let curpos = getpos('.')
+            let curpos[1] = pos[0]
+            let curpos[2] = pos[1]
+            call setpos('.', curpos)
+        else
+            call winrestview(s:stateSaved)
+        endif
+    else
+        call winrestview(s:stateSaved)
+    endif
+
+    if s:hlsearchSaved && !empty(pattern)
+        set hlsearch
+    else
+        set nohlsearch
+    endif
+    redraw
+endfunction
+
+function! s:onLeave()
+    call s:delayUpdateCancel()
+
+    if exists('s:hlsearchSaved')
+        let hlsearchSaved = s:hlsearchSaved
+        unlet s:hlsearchSaved
+    endif
+    if exists('s:patternSaved')
+        let patternSaved = s:patternSaved
+        unlet s:patternSaved
+    endif
+    if exists('s:stateSaved')
+        let stateSaved = s:stateSaved
+        unlet s:stateSaved
+    endif
+
+    if exists('hlsearchSaved')
+        if hlsearchSaved
+            set hlsearch
+        else
+            set nohlsearch
+        endif
+    endif
+
+    if has('nvim')
+        let abort = get(v:event, 'abort', 0)
+    else
+        let abort = get(s:, 'eregex_incsearch_abort', 0)
+    endif
+    if !abort
+        return
+    endif
+
+    if exists('patternSaved')
+        let @/ = patternSaved
+    endif
+    if exists('stateSaved')
+        call winrestview(stateSaved)
+    endif
+
+    redraw!
+endfunction
+
+" input: M/abc
+" output: {
+"   'method' : 'M'
+"   'pattern' : 'abc'
+" }
+"
+" input: 1,3S/abc/xyz/g
+" output: {
+"   'method' : 'S',
+"   'pattern' : 'abc',
+" }
+function! s:cmdParse(cmdline)
+    let token = nr2char(127)
+    let items = split(substitute(a:cmdline, '\\/', token, 'g'), '/', 1)
+    if len(items) < 2
+        return {}
+    endif
+    let modes = get(b:, 'eregex_incsearch_modes', get(g:, 'eregex_incsearch_modes', 'MSGV'))
+    " ^[0-9,\.\$%]*([MSGV])\/.*$
+    let method = substitute(items[0], '^[0-9,\.\$%]*\([' . modes . ']\)\/.*$', '\1', '')
+    if empty(method)
+        return {}
+    endif
+    return {
+                \   'method' : method,
+                \   'pattern' : substitute(get(items, 1, ''), token, '\\/', 'g'),
+                \ }
+endfunction
+

--- a/plugin/incsearch.vim
+++ b/plugin/incsearch.vim
@@ -50,6 +50,17 @@ function! s:onUpdate()
     if empty(cmd)
         return
     endif
+    let Fn_filter = get(b:, 'Fn_eregex_incsearch_filter', get(g:, 'Fn_eregex_incsearch_filter', ''))
+    if !empty(Fn_filter) && Fn_filter(cmd['pattern'])
+        if exists('s:patternSaved')
+            let @/ = s:patternSaved
+        endif
+        if exists('s:stateSaved')
+            call winrestview(s:stateSaved)
+        endif
+        redraw!
+        return
+    endif
     let pattern = E2v(cmd['pattern'])
 
     if !exists('s:hlsearchSaved')


### PR DESCRIPTION
add incsearch support, for `:M/` `:S/` `:G/` `:V/` command, and `:M?` backward search series

limitations:

* require `exists('##CmdlineChanged') && exists('##CmdlineLeave')`, to simulate incsearch
    * it seems possible by `cmap` `a to z` to simulate incsearch, but that would cause much more trouble
* require `has('timers')`, to prevent some buggy behavior when used in keymaps, such as `nnoremap xxx :S/<c-r><c-w>`
* for `vim`, added a `cmap <cr>` due to lack of `neovim`'s `v:event['abort']` of `CmdlineLeave`, which may break user's custom keymap
    * if unable to detect the "abort" state, incsearch still work, but the original search pattern can't be restored if `:M/` canceled by `<esc>` or `<c-c>`